### PR TITLE
Nl event listeners

### DIFF
--- a/src/scripts/listeners.js
+++ b/src/scripts/listeners.js
@@ -1,4 +1,34 @@
 /*
-  author(s):
+  author(s): Nolan
   purpose: module contains a function for adding event listeners
 */
+
+// callback function for form submit event listeners
+let getFormValues = (target) => {
+  /*
+  target = current target(form which contains the button being clicked/submitted)
+  set value of formDivs to an iterable node list of all input fields
+  */
+  let formDivs = target.querySelectorAll(".input-field")
+
+  // create object to return
+  let formValuesObj = {}
+
+  // iterate through nodelist and assign each input id as the key and the input value as the value in the object
+  formDivs.forEach((input) => {
+    formValuesObj[input.firstElementChild.id] = input.firstElementChild.value
+  })
+  return formValuesObj
+}
+
+
+/*
+example of how we would attach the event listener to a form and pass the current target of the event to
+the getFormValues function. This example consoles the object that would be returned from the function
+*/
+let form = document.querySelector("form").addEventListener("click", (e) => {
+  let newsValues = getFormValues(e.currentTarget)
+  console.log("object to post", newsValues)
+})
+
+export default getFormValues

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,0 +1,2 @@
+import getFormValues from "./listeners"
+


### PR DESCRIPTION
added callback function for using in our form event listeners.   
  -returns an object with key:value pairs matching our databse.

contains an example event listener attached to our hard coded html form on "click" as it is a button and our form doesn't submit. clicking anywhere on the form will console log the current form values in the object.